### PR TITLE
Bump LocalzDriverSDK version to 1.6.3

### DIFF
--- a/LocalzDriverSDK/1.6.3/LocalzDriverSDK.podspec
+++ b/LocalzDriverSDK/1.6.3/LocalzDriverSDK.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |s|
+
+	s.name = "LocalzDriverSDK"
+	s.summary = "iOS library for LocalzDriverSDK"
+
+	s.version = "1.6.3"
+	s.platform = :ios, "9.0"
+	s.ios.deployment_target = '9.0'
+
+	s.homepage = "http://www.localz.com"
+	s.license = {
+		:type => 'Commercial',
+		:text => <<-LICENSE
+			Copyright 2019 Localz Pty Ltd.
+			LICENSE
+	}
+	s.author = { 'Localz Pty Ltd' => 'info@localz.com' }
+	s.source = { :git => 'https://github.com/localz/Localz-Driver-iOS-SDK.git',
+				 :tag => s.version }
+
+	s.requires_arc = true
+	s.frameworks = 'UIKit','Foundation','SystemConfiguration','CoreLocation'
+	s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited)' }
+	s.vendored_frameworks = 'LocalzDriverSDK/LocalzDriverSDK.framework'
+	s.dependency 'SpotzRTSDK', '~> 3.4.3'
+	s.dependency 'LocalzPushSDK'
+end


### PR DESCRIPTION
### Feature Overview:

- Support points params and serialisation on eta for order response.

## Tests:

- N/A